### PR TITLE
Corrected Chapter 1 link

### DIFF
--- a/text/chapter03.html
+++ b/text/chapter03.html
@@ -10,7 +10,7 @@
 
 <h3><a id="image_fills">Image Fills</a></h3>
 
-<p>In <a href="chapter1.html">Chapter 1</a> we learned that Canvas can fill shapes with colors and gradients.  You can also fill shapes with images by defining a pattern. You can control how the pattern is repeated the same as you would with background images in CSS.</p>
+<p>In <a href="chapter01.html">Chapter 1</a> we learned that Canvas can fill shapes with colors and gradients.  You can also fill shapes with images by defining a pattern. You can control how the pattern is repeated the same as you would with background images in CSS.</p>
 
 <!--
 


### PR DESCRIPTION
Chapter 3 para 1 has a link to Chapter 1 "chapter1.html" — it should be "chapter01.html"
